### PR TITLE
Add notice / README note about using longjohn in production code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ So what to do...  I stole the code and rewrote it.  I've added support for remov
 
 Please thank [tlrobinson](https://github.com/tlrobinson) for the initial implementation!
 
+## Production Use
+
+Longjohn collects a large amount of data in order to provide useful stack traces. While it is very helpful in
+development and testing environments, it is not recommended to use longjohn in production. The data collection puts
+a lot of strain on V8's garbage collector and can greatly slow down heavily-loaded applications. 
+
 ## Installation
 
 Just npm install it!
@@ -23,7 +29,9 @@ $ npm install longjohn
 To use longjohn, require it in your code (probably in some initialization code).  That's all!
 
 ```javascript
-require('longjohn');
+if (process.env.NODE_ENV !== 'production'){
+  require('longjohn');
+}
 
 // ... your code
 ```

--- a/dist/longjohn.js
+++ b/dist/longjohn.js
@@ -314,4 +314,8 @@
 
   Error.prepareStackTrace = prepareStackTrace;
 
+  if (process.env.NODE_ENV === 'production') {
+    console.warn('NOTICE: Longjohn is known to cause CPU usage due to its extensive data collection during runtime.\nIt generally should not be used in production applications.');
+  }
+
 }).call(this);

--- a/lib/longjohn.coffee
+++ b/lib/longjohn.coffee
@@ -223,3 +223,9 @@ if global.setImmediate?
     _setImmediate.apply(this, args)
 
 Error.prepareStackTrace = prepareStackTrace
+
+if process.env.NODE_ENV == 'production'
+  console.warn '''
+    NOTICE: Longjohn is known to cause CPU usage due to its extensive data collection during runtime.
+    It generally should not be used in production applications.
+  '''


### PR DESCRIPTION
As mentioned by @visionmedia in #19, longjohn causes high GC & CPU usage and should not be used in production. Anecdotally, a heavy application I have been writing operates at 60-80% CPU usage with longjohn enabled and <10% CPU without.

This PR adds a warning on runtime and a small header in the README.
