### PR TITLE
Upgrade to grunt 0.4.0, reduce devDependencies down to grunt-contrib-coffee.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,6 +1,6 @@
 module.exports = function(grunt) {
   
-  grunt.loadNpmTasks('grunt-contrib');
+  grunt.loadNpmTasks('grunt-contrib-coffee');
 
   // Project configuration.
   grunt.initConfig({
@@ -8,7 +8,7 @@ module.exports = function(grunt) {
     coffee: {
       compile: {
         files: {
-          'dist/*.js': 'lib/*.coffee'
+          'dist/longjohn.js': 'lib/longjohn.coffee'
         }
       }
     }

--- a/dist/longjohn.js
+++ b/dist/longjohn.js
@@ -69,11 +69,12 @@
   };
 
   exports.format_stack = function(err, frames) {
-    var lines;
+    var e, lines;
     lines = [];
     try {
       lines.push(err.toString());
-    } catch (e) {
+    } catch (_error) {
+      e = _error;
       console.log('Caught error in longjohn. Please report this to matt.insler@gmail.com.');
     }
     lines.push.apply(lines, frames.map(exports.format_stack_frame));
@@ -113,7 +114,7 @@
       error.__cached_trace__ = structured_stack_trace.filter(function(f) {
         return f.getFileName() !== filename;
       });
-      if (!(error.__previous__ != null) && in_prepare === 1) {
+      if ((error.__previous__ == null) && in_prepare === 1) {
         error.__previous__ = current_trace_error;
       }
       if (error.__previous__ != null) {
@@ -172,11 +173,13 @@
     trace_error.__trace_count__ = current_trace_error != null ? current_trace_error.__trace_count__ + 1 : 1;
     limit_frames(trace_error);
     new_callback = function() {
+      var e;
       current_trace_error = trace_error;
       trace_error = null;
       try {
         return callback.apply(this, arguments);
-      } catch (e) {
+      } catch (_error) {
+        e = _error;
         e.stack;
         throw e;
       } finally {

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "node": ">= 0.6.0"
   },
   "devDependencies": {
-    "grunt": "~0.3.15",
-    "grunt-contrib": "~0.3.0",
+    "grunt": "~0.4.0",
+    "grunt-contrib-coffee": "~0.7.0",
     "mocha": "latest",
     "coffee-script": "latest"
   },


### PR DESCRIPTION
No need to import the entirety of grunt-contrib.

Upgraded to grunt 0.4.0 so we can use the newest grunt-contrib-coffee version. File syntax is a little different so I updated that. Tests & compiles are still working.
