### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,12 +15,7 @@
   "bugs": {
     "url": "https://github.com/mattinsler/longjohn/issues"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/mattinsler/longjohn/blob/master/LICENSE-MIT"
-    }
-  ],
+  "license": "MIT",
   "main": "dist/longjohn",
   "engines": {
     "node": ">= 0.6.0"


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/