### PR TITLE
remove util.Function. bump node engine version

### DIFF
--- a/dist/longjohn.js
+++ b/dist/longjohn.js
@@ -1,9 +1,7 @@
 (function() {
-  var ERROR_ID, EventEmitter, create_callsite, current_trace_error, filename, format_location, format_method, in_prepare, limit_frames, prepareStackTrace, source_map, util, wrap_callback, __nextDomainTick, _addListener, _listeners, _nextTick, _on, _ref, _setImmediate, _setInterval, _setTimeout;
+  var ERROR_ID, EventEmitter, create_callsite, current_trace_error, filename, format_location, format_method, in_prepare, limit_frames, prepareStackTrace, source_map, wrap_callback, __nextDomainTick, _addListener, _listeners, _nextTick, _on, _ref, _setImmediate, _setInterval, _setTimeout;
 
   EventEmitter = require('events').EventEmitter;
-
-  util = require('util');
 
   if ((_ref = EventEmitter.prototype.on) != null ? _ref['longjohn'] : void 0) {
     return module.exports = EventEmitter.prototype.on['longjohn'];
@@ -223,7 +221,7 @@
   EventEmitter.prototype.once = function(event, callback) {
     var args, fired, g, wrap;
     args = Array.prototype.slice.call(arguments);
-    if (!util.isFunction(callback)) {
+    if (typeof callback !== 'function') {
       throw TypeError('callback must be a function');
     }
     fired = false;

--- a/lib/longjohn.coffee
+++ b/lib/longjohn.coffee
@@ -1,5 +1,4 @@
 {EventEmitter} = require 'events'
-util = require 'util'
 if EventEmitter.prototype.on?['longjohn']
   return module.exports = EventEmitter.prototype.on['longjohn']
 
@@ -160,7 +159,7 @@ EventEmitter.prototype.on = (event, callback) ->
 
 EventEmitter.prototype.once = (event, callback) ->
   args = Array::slice.call(arguments)
-  if !util.isFunction(callback)
+  if typeof callback != 'function'
     throw TypeError('callback must be a function');
   fired = false
   wrap = wrap_callback(callback, 'EventEmitter.once');

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "license": "MIT",
   "main": "dist/longjohn",
   "engines": {
-    "node": ">= 0.6.0"
+    "node": ">= 0.9.3"
   },
   "devDependencies": {
     "grunt": "~0.4.0",


### PR DESCRIPTION
Version 0.2.10 is actually not backward compatible. So first commit restore it.
Also, I've checked latest tests on all node versions from 0.8.6 to 0.5.0 and found that first compatible version is 0.9.3.