### PR TITLE
Fix compatibility with older node versions

### DIFF
--- a/lib/longjohn.coffee
+++ b/lib/longjohn.coffee
@@ -160,7 +160,7 @@ EventEmitter.prototype.on = (event, callback) ->
 
 EventEmitter.prototype.once = (event, callback) ->
   args = Array::slice.call(arguments)
-  if !util.isFunction(callback)
+  if typeof callback !== 'function'
     throw TypeError('callback must be a function');
   fired = false
   wrap = wrap_callback(callback, 'EventEmitter.once');


### PR DESCRIPTION
Note of warning: I'm not familiar with this CoffeeScript, so I'm not sure if this is legal syntax. Please let me know and I'll update the PR.

The `util.isFunction` helper function wasn't added until Node 0.12.

If you look at [the Node.js source code](https://github.com/nodejs/node/blob/15dc37ff4f24584bb480381b5465837ff8a2aae2/lib/util.js#L752) for the function all it does is a `typeof`, so it should be perfectly safe to do the same here.