### PR TITLE
[package] Allow newer versions of source-map-support.

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,6 @@
   },
   "keywords": [],
   "dependencies": {
-    "source-map-support": "0.3.2"
+    "source-map-support": "0.3.2 - 1.0.0"
   }
 }


### PR DESCRIPTION
I’m using the latest version of babel-node and with the version of source-map-support pinned by longjohn the symbolicated stack traces are incorrect. This change allows newer versions, I did constraint it to < 1.0.0 just in case, but I don’t feel strongly about it so can remove it if you prefer.